### PR TITLE
feat: add search box to filter table rows by text

### DIFF
--- a/src/SearchHandler.ts
+++ b/src/SearchHandler.ts
@@ -1,0 +1,35 @@
+import { AgentableRow, ColumnDef } from './types';
+
+/**
+ * Ephemeral, per-instance free-text search that filters rows client-side.
+ * Unlike FilterHandler/SortHandler, the query is intentionally not persisted
+ * to the table's saved data - it's a transient view-only filter, reset when
+ * the note is closed and reopened.
+ */
+export class SearchHandler {
+  private query = '';
+
+  public getQuery(): string {
+    return this.query;
+  }
+
+  public setQuery(query: string): void {
+    this.query = query;
+  }
+
+  public hasActiveSearch(): boolean {
+    return this.query.trim().length > 0;
+  }
+
+  public getSearchedRows(rows: AgentableRow[], columns: ColumnDef[]): AgentableRow[] {
+    const query = this.query.trim().toLowerCase();
+    if (!query) return rows;
+
+    return rows.filter(row =>
+      columns.some(col => {
+        const cellValue = row.cells[col.id];
+        return cellValue != null && String(cellValue).toLowerCase().includes(query);
+      })
+    );
+  }
+}

--- a/src/icons.ts
+++ b/src/icons.ts
@@ -31,6 +31,7 @@ export const ICON_NAMES = {
   switch: 'repeat-2',
   wrapText: 'wrap-text',
   chevronRight: 'chevron-right',
+  search: 'search',
 } as const;
 
 /**

--- a/src/renderers/AbstractTableRenderer.ts
+++ b/src/renderers/AbstractTableRenderer.ts
@@ -14,6 +14,7 @@ import { DateRenderer } from './DateRenderer';
 import { NumberRenderer } from './NumberRenderer';
 import { SortHandler } from '../SortHandler';
 import { FilterHandler } from '../FilterHandler';
+import { SearchHandler } from '../SearchHandler';
 import { ICON_NAMES, createIconElement } from '../icons';
 import { generateCsv, downloadCsv } from '../utils/csv';
 import { createDefaultView } from '../utils/fileUtils';
@@ -41,6 +42,13 @@ export abstract class AbstractTableRenderer implements IViewManagerHost, IMenuMa
     protected isResizing: boolean = false;
     protected sortHandler: SortHandler;
     protected filterHandler: FilterHandler;
+    protected searchHandler: SearchHandler;
+    // Set at the start of render() when the search box currently has real DOM
+    // focus, so renderControls() can restore it after the DOM is rebuilt.
+    // Deliberately re-derived from document.activeElement every render instead
+    // of tracked via focus/blur listeners, so a stale value can never cause an
+    // unrelated re-render to steal focus back into the search box.
+    protected pendingSearchFocus: { cursor: number | null } | null = null;
     public activeViewId: string;
     public isInline: boolean;
     public lockToView: boolean = false;
@@ -71,6 +79,7 @@ export abstract class AbstractTableRenderer implements IViewManagerHost, IMenuMa
 
         this.sortHandler = new SortHandler(this.data, () => this.render(), this.view, () => this.getActiveView());
         this.filterHandler = new FilterHandler(this.data, () => this.render(), this.view, () => this.getActiveView());
+        this.searchHandler = new SearchHandler();
     }
 
     // --- Abstract Methods ---
@@ -131,6 +140,10 @@ export abstract class AbstractTableRenderer implements IViewManagerHost, IMenuMa
         return this.data.columns.filter(col => !hiddenCols.includes(col.id));
     }
 
+    protected getSearchFilteredRows(rows: AgentableRow[]): AgentableRow[] {
+        return this.searchHandler.getSearchedRows(rows, this.getVisibleColumns());
+    }
+
     // --- Shared Rendering Components ---
 
     protected renderRenameInput() {
@@ -165,6 +178,34 @@ export abstract class AbstractTableRenderer implements IViewManagerHost, IMenuMa
         const propsIcon = createIconElement(ICON_NAMES.eye, 14, 'icon-props');
         propsButton.appendChild(propsIcon); propsButton.appendText(' Show/hide');
         propsButton.addEventListener('click', (e) => this.showPropertyVisibilityPopup(propsButton, e));
+
+        // Search
+        const searchContainer = leftControls.createDiv({ cls: 'json-table-search-container' });
+        searchContainer.appendChild(createIconElement(ICON_NAMES.search, 14, 'icon-search'));
+        const searchInput = searchContainer.createEl('input', {
+            type: 'text',
+            cls: 'json-table-search-input',
+            attr: { placeholder: 'Search rows...' },
+        });
+        searchInput.value = this.searchHandler.getQuery();
+        searchInput.addEventListener('click', (e) => e.stopPropagation());
+        searchInput.addEventListener('mousedown', (e) => e.stopPropagation());
+
+        let searchDebounceTimer: ReturnType<typeof setTimeout>;
+        searchInput.addEventListener('input', () => {
+            this.searchHandler.setQuery(searchInput.value);
+            clearTimeout(searchDebounceTimer);
+            searchDebounceTimer = setTimeout(() => this.render(), 200);
+        });
+
+        // Restore focus/cursor only if the search box truly had focus right
+        // before this render rebuilt the DOM (see pendingSearchFocus above).
+        if (this.pendingSearchFocus) {
+            searchInput.focus();
+            if (typeof this.pendingSearchFocus.cursor === 'number') {
+                searchInput.setSelectionRange(this.pendingSearchFocus.cursor, this.pendingSearchFocus.cursor);
+            }
+        }
 
         // Settings
         const settingsButton = rightControls.createEl('button', { cls: 'json-table-btn json-table-btn--icon json-table-settings-button', attr: { 'aria-label': 'Table settings', title: 'Table settings' } });
@@ -202,7 +243,8 @@ export abstract class AbstractTableRenderer implements IViewManagerHost, IMenuMa
     }
 
     public exportViewToCsv() {
-        const csvContent = generateCsv(this.getVisibleColumns(), this.filterHandler.getFilteredRows(this.sortHandler.getSortedRows()));
+        const rows = this.getSearchFilteredRows(this.filterHandler.getFilteredRows(this.sortHandler.getSortedRows()));
+        const csvContent = generateCsv(this.getVisibleColumns(), rows);
         const filename = (this.view.getDisplayText() || 'view_export') + '_view.csv';
         downloadCsv(filename, csvContent);
     }

--- a/src/renderers/DivTableRenderer.ts
+++ b/src/renderers/DivTableRenderer.ts
@@ -25,6 +25,16 @@ export class DivTableRenderer extends AbstractTableRenderer {
         const scrollLeft = existingWrapper?.scrollLeft ?? 0;
         const scrollTop = existingWrapper?.scrollTop ?? 0;
 
+        // Capture real focus state before the container (and the search input
+        // living inside it) gets destroyed and rebuilt below. This must be read
+        // fresh from the DOM on every render rather than tracked with a
+        // persistent focus/blur flag, otherwise a stale flag can cause an
+        // unrelated re-render (e.g. editing a cell) to steal focus back into
+        // the search box - which is exactly what breaks things like Cmd/Ctrl+A.
+        const activeEl = document.activeElement as HTMLInputElement | null;
+        const searchHadFocus = !!activeEl && this.container.contains(activeEl) && activeEl.classList.contains('json-table-search-input');
+        this.pendingSearchFocus = searchHadFocus ? { cursor: activeEl.selectionStart } : null;
+
         this.container.empty();
         this.renderRenameInput();
         this.renderViewTabs();
@@ -36,7 +46,7 @@ export class DivTableRenderer extends AbstractTableRenderer {
             tableWrapper.addClass('is-sticky-actions');
         }
 
-        const rowsToRender = this.filterHandler.getFilteredRows(this.sortHandler.getSortedRows());
+        const rowsToRender = this.getSearchFilteredRows(this.filterHandler.getFilteredRows(this.sortHandler.getSortedRows()));
 
         this.renderHeader(tableWrapper);
         this.renderBody(tableWrapper, rowsToRender);
@@ -345,7 +355,7 @@ export class DivTableRenderer extends AbstractTableRenderer {
             });
 
             // Check if all filtered rows are selected
-            const rowsToRender = this.filterHandler.getFilteredRows();
+            const rowsToRender = this.getSearchFilteredRows(this.filterHandler.getFilteredRows());
             const allSelected = rowsToRender.length > 0 &&
                 rowsToRender.every(row => {
                     const originalIndex = this.data.rows.indexOf(row);

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1235,6 +1235,46 @@ div.json-table-btn--active:hover {
   gap: 8px;
 }
 
+.json-table-search-container {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 6px;
+  border-radius: 4px;
+  background: transparent;
+  border: none;
+
+  .icon-search {
+    color: var(--text-faint);
+    display: flex;
+  }
+}
+
+// Obsidian's base theme styles bare `input[type="text"]` elements with a
+// border/background of their own, at a specificity that beats a single class
+// selector - so the reset has to be repeated across interaction states with
+// !important to reliably stay flat/borderless (Notion-style) in every theme.
+.json-table-search-input,
+.json-table-search-input:hover,
+.json-table-search-input:focus,
+.json-table-search-input:focus-visible {
+  border: none !important;
+  background: transparent !important;
+  outline: none !important;
+  box-shadow: none !important;
+}
+
+.json-table-search-input {
+  font-size: inherit;
+  color: var(--text-normal);
+  width: 140px;
+  padding: 0;
+
+  &::placeholder {
+    color: var(--text-faint);
+  }
+}
+
 .json-table-header-buttons-container {
   display: flex;
   gap: 8px;


### PR DESCRIPTION
Adds a free-text search box to the table toolbar (next to Sort/Filter/ Show-hide) that filters rows client-side by matching against any visible column's cell value, case-insensitively. The query is ephemeral per-view state, not persisted to the saved table data, mirroring how Sort/Filter are structured (SearchHandler alongside SortHandler/FilterHandler).

Styled to match a flat, borderless search affordance (no visible box), consistent with the rest of the toolbar. Obsidian's base theme styles bare input[type="text"] elements with their own border/background at a specificity that beats a single class selector, so the reset is repeated across hover/focus states with !important to stay borderless in every theme.

Focus/cursor position is preserved across re-renders (e.g. while typing, which triggers a debounced re-render) by re-deriving "does the search box currently have real DOM focus" from document.activeElement at the start of every render, rather than tracking it with persistent focus/blur listeners - a stateful flag can go stale and cause an unrelated re-render to steal focus back into the search box.

Closes #15

<img width="1136" height="175" alt="Screenshot 2026-07-06 at 17 31 50" src="https://github.com/user-attachments/assets/7e90fccc-24e8-42a1-8cd1-579948c58ff4" />

